### PR TITLE
Fixing indentation on topology block for kops template

### DIFF
--- a/clusters/aws/kops/template/cluster.yml
+++ b/clusters/aws/kops/template/cluster.yml
@@ -268,11 +268,11 @@ spec:
     zone: {{ $awsRegion }}{{ $value.zone }}
     {{- end }}
 
-    topology:
-      dns:
-        type: {{ .topology.dns.type }}
-      masters: {{ .topology.masters }}
-      nodes: {{ .topology.nodes }}
+  topology:
+    dns:
+      type: {{ .topology.dns.type }}
+    masters: {{ .topology.masters }}
+    nodes: {{ .topology.nodes }}
     #
     # Kubernetes Masters
     #


### PR DESCRIPTION
Fixing indentation on topology block. Using private DNS zone was not properly pulling values from `cluster/values.yaml`